### PR TITLE
docs: refresh tool count 46 → 61 across all skills

### DIFF
--- a/efecto/skills/graphic-design/SKILL.md
+++ b/efecto/skills/graphic-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 46 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -96,7 +96,7 @@ batch_update  updates: [
 ]
 ```
 
-### All 46 Tools
+### All 61 Tools
 
 | Category | Tools |
 |----------|-------|

--- a/efecto/skills/social-media/SKILL.md
+++ b/efecto/skills/social-media/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 46 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -97,7 +97,7 @@ batch_update  updates: [
 ]
 ```
 
-### All 46 Tools
+### All 61 Tools
 
 | Category | Tools |
 |----------|-------|

--- a/efecto/skills/web-design/SKILL.md
+++ b/efecto/skills/web-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 46 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ---
 
@@ -139,7 +139,7 @@ Repeat Steps 4-6 to add more sections, adjust styling, and refine the design. Th
 
 ---
 
-## The 46 Design Tools
+## The 61 Design Tools
 
 ### Reading State
 

--- a/skills/graphic-design/SKILL.md
+++ b/skills/graphic-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 46 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -96,7 +96,7 @@ batch_update  updates: [
 ]
 ```
 
-### All 46 Tools
+### All 61 Tools
 
 | Category | Tools |
 |----------|-------|

--- a/skills/social-media/SKILL.md
+++ b/skills/social-media/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 46 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -97,7 +97,7 @@ batch_update  updates: [
 ]
 ```
 
-### All 46 Tools
+### All 61 Tools
 
 | Category | Tools |
 |----------|-------|

--- a/skills/web-design/SKILL.md
+++ b/skills/web-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 46 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ---
 
@@ -139,7 +139,7 @@ Repeat Steps 4-6 to add more sections, adjust styling, and refine the design. Th
 
 ---
 
-## The 46 Design Tools
+## The 61 Design Tools
 
 ### Reading State
 


### PR DESCRIPTION
## Summary

Drive-by from PR #4. The canonical manifest at `lib/studio/tool-manifest.ts` in the efecto-app repo has 61 entries (+ 4 session tools). Public skill copy was frozen at 46. Updates every reference across both install paths:

- `skills/{social-media,web-design,graphic-design}/SKILL.md` — 6 spots
- `efecto/skills/{social-media,web-design,graphic-design}/SKILL.md` — 6 spots

12 mentions total. Pure search-and-replace — no other prose edits.

Original PR (#4) merged before this commit landed on the branch; opening fresh so the change isn't orphaned.

## Test plan

- [ ] `grep -rn "46 design tools\|All 46 Tools\|The 46 Design Tools" skills/ efecto/skills/` returns nothing.
- [ ] `npx skills add pablostanley/efecto-plugin` shows "61 design tools" in the install banner / skill content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)