### PR TITLE
Document native animation tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,13 @@ Install skills + MCP tools:
 npx skills add pablostanley/efecto-plugin
 ```
 
-This installs 3 design skills and configures the Efecto MCP server with 46 design tools.
+This installs 3 design skills and configures the Efecto MCP server with 69 tools.
 
 ## MCP Server
 
-The Efecto MCP server gives you 46 tools to create and modify designs in real-time:
+The Efecto MCP server gives you 69 tools to create, modify, animate, and export designs in real-time:
 
-- **Session**: `create_session`, `wait_for_connection`, `session_status`, `close_session`
+- **Session**: `create_session`, `attach_session`, `wait_for_connection`, `session_status`, `close_session`
 - **Reading**: `get_document`, `get_selection`, `get_node_tree`, `list_artboards`, `find_nodes`
 - **Creating**: `create_artboard`, `add_section`, `add_node`
 - **Modifying**: `update_node`, `update_class`, `update_artboard`, `batch_update`, `replace_section`
@@ -29,6 +29,7 @@ The Efecto MCP server gives you 46 tools to create and modify designs in real-ti
 - **History**: `undo`, `redo`
 - **Theme**: `get_theme`, `set_theme`, `set_theme_mode`, `reset_theme`
 - **Quality**: `audit_design`, `repair_design`
+- **Animation**: `list_animation_presets`, `apply_animation_plan`, `clear_animations`
 
 ## Workflow
 
@@ -50,5 +51,5 @@ The 3 installed skills provide design knowledge:
 ## Documentation
 
 - Full docs: https://efecto.app/docs
-- All 46 tools: https://efecto.app/docs/tools
+- All 69 tools: https://efecto.app/docs/tools
 - Skills guide: https://efecto.app/docs/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@ Install skills + MCP tools:
 npx skills add pablostanley/efecto-plugin
 ```
 
-This installs 3 design skills and configures the Efecto MCP server with 69 tools.
+This installs 3 design skills and configures the Efecto MCP server with 68 tools.
 
 ## MCP Server
 
-The Efecto MCP server gives you 69 tools to create, modify, animate, and export designs in real-time:
+The Efecto MCP server gives you 68 tools to create, modify, animate, and export designs in real-time:
 
 - **Session**: `create_session`, `attach_session`, `wait_for_connection`, `session_status`, `close_session`
 - **Reading**: `get_document`, `get_selection`, `get_node_tree`, `list_artboards`, `find_nodes`
@@ -51,5 +51,5 @@ The 3 installed skills provide design knowledge:
 ## Documentation
 
 - Full docs: https://efecto.app/docs
-- All 69 tools: https://efecto.app/docs/tools
+- All 68 tools: https://efecto.app/docs/tools
 - Skills guide: https://efecto.app/docs/skills

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Works with **Claude Code**, **Cursor**, **Windsurf**, **GitHub Copilot**, **Code
 npx skills add pablostanley/efecto-plugin
 ```
 
-This installs **3 design skills** (knowledge) + **66 MCP tools** (actions). Your AI agent gets both the taste and the tools.
+This installs **3 design skills** (knowledge) + **69 MCP tools** (actions). Your AI agent gets both the taste and the tools.
 
 <details>
 <summary>Other install methods</summary>
@@ -59,9 +59,9 @@ codex mcp add efecto -- npx -y @efectoapp/mcp
 
 ## What's Included
 
-### 66 MCP Tools
+### 69 MCP Tools
 
-Create sessions, build artboards, add layouts with JSX + Tailwind CSS, modify nodes, export images, manage themes, and more. Full programmatic control of the Efecto design canvas.
+Create sessions, build artboards, add layouts with JSX + Tailwind CSS, modify nodes, animate layers, export images, manage themes, and more. Full programmatic control of the Efecto design canvas.
 
 ### 3 Design Skills
 
@@ -90,11 +90,12 @@ Just ask your AI to design something:
 - "Make a pitch deck for our Series A"
 - "Design a business card for my agency"
 - "Create a YouTube thumbnail for my video"
+- "Animate this artboard with a clean staggered entrance"
 
 ## Links
 
 - [Efecto App](https://efecto.app)
 - [Documentation](https://efecto.app/docs)
 - [Skills Guide](https://efecto.app/docs/skills)
-- [All 66 Tools](https://efecto.app/docs/tools)
+- [All 69 Tools](https://efecto.app/docs/tools)
 - [MCP Package](https://www.npmjs.com/package/@efectoapp/mcp)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Works with **Claude Code**, **Cursor**, **Windsurf**, **GitHub Copilot**, **Code
 npx skills add pablostanley/efecto-plugin
 ```
 
-This installs **3 design skills** (knowledge) + **69 MCP tools** (actions). Your AI agent gets both the taste and the tools.
+This installs **3 design skills** (knowledge) + **68 MCP tools** (actions). Your AI agent gets both the taste and the tools.
 
 <details>
 <summary>Other install methods</summary>
@@ -59,7 +59,7 @@ codex mcp add efecto -- npx -y @efectoapp/mcp
 
 ## What's Included
 
-### 69 MCP Tools
+### 68 MCP Tools
 
 Create sessions, build artboards, add layouts with JSX + Tailwind CSS, modify nodes, animate layers, export images, manage themes, and more. Full programmatic control of the Efecto design canvas.
 
@@ -97,5 +97,5 @@ Just ask your AI to design something:
 - [Efecto App](https://efecto.app)
 - [Documentation](https://efecto.app/docs)
 - [Skills Guide](https://efecto.app/docs/skills)
-- [All 69 Tools](https://efecto.app/docs/tools)
+- [All 68 Tools](https://efecto.app/docs/tools)
 - [MCP Package](https://www.npmjs.com/package/@efectoapp/mcp)

--- a/efecto/skills/graphic-design/SKILL.md
+++ b/efecto/skills/graphic-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -96,14 +96,15 @@ batch_update  updates: [
 ]
 ```
 
-### All 66 Tools
+### All 69 Tools
 
 | Category | Tools |
 |----------|-------|
 | **Session** | `create_session`, `attach_session`, `wait_for_connection`, `session_status`, `close_session` |
 | **Reading** | `get_document`, `get_selection`, `get_node_tree`, `list_artboards`, `find_nodes` |
 | **Creating** | `create_artboard`, `add_section`, `add_node` |
-| **Modifying** | `update_node`, `update_class`, `update_artboard` (now accepts `speakerNotes` for slides), `batch_update`, `replace_section` |
+| **Modifying** | `update_node`, `update_class`, `update_artboard` (accepts `speakerNotes` for slides and `timelineDuration` for animation), `batch_update`, `replace_section` |
+| **Animation** | `list_animation_presets`, `apply_animation_plan`, `clear_animations` |
 | **Organizing** | `move_node`, `duplicate_node`, `duplicate_artboard`, `group_nodes`, `ungroup_node`, `reorder_node` |
 | **Selection** | `select_nodes`, `deselect_all`, `set_visibility`, `delete_nodes`, `delete_artboard` |
 | **Alignment** | `align_nodes`, `distribute_nodes` |
@@ -217,6 +218,16 @@ add_node
 ```
 
 **Best for**: Presentation backgrounds, poster visuals, event graphics, blog hero images, OG cards with distinctive visual treatments.
+
+---
+
+## Native Animation
+
+Graphic assets can use native Efecto layer animations when the user asks for motion, slides, reels, or presentation playback. Do not use Tailwind `animate-*`, `transition-*`, or `duration-*` classes.
+
+Workflow: inspect the target, call `list_animation_presets`, then apply a compact plan with `apply_animation_plan`. Animate hierarchy first: background or hero visual, headline, supporting detail, CTA or event details, then secondary ornaments. Use `update_artboard` with `timelineDuration` when the motion needs a deliberate ending.
+
+Good defaults: 0.35-0.6s for hero/title motion, 0.18-0.35s for smaller details, 0.04-0.12s stagger, `ease-out` entrances, `ease-in` exits. For title text, use `appearBy: "word"` or `"line"`; reserve `"char"` for kinetic poster moments.
 
 ---
 

--- a/efecto/skills/graphic-design/SKILL.md
+++ b/efecto/skills/graphic-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 68 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -96,7 +96,7 @@ batch_update  updates: [
 ]
 ```
 
-### All 69 Tools
+### All 68 Tools
 
 | Category | Tools |
 |----------|-------|

--- a/efecto/skills/social-media/SKILL.md
+++ b/efecto/skills/social-media/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -97,7 +97,7 @@ batch_update  updates: [
 ]
 ```
 
-### All 66 Tools
+### All 69 Tools
 
 | Category | Tools |
 |----------|-------|
@@ -105,6 +105,7 @@ batch_update  updates: [
 | **Reading** | `get_document`, `get_selection`, `get_node_tree`, `list_artboards`, `find_nodes` |
 | **Creating** | `create_artboard`, `add_section`, `add_node` |
 | **Modifying** | `update_node`, `update_class`, `update_artboard`, `batch_update`, `replace_section` |
+| **Animation** | `list_animation_presets`, `apply_animation_plan`, `clear_animations` |
 | **Organizing** | `move_node`, `duplicate_node`, `duplicate_artboard`, `group_nodes`, `ungroup_node`, `reorder_node` |
 | **Selection** | `select_nodes`, `deselect_all`, `set_visibility`, `delete_nodes`, `delete_artboard` |
 | **Alignment** | `align_nodes`, `distribute_nodes` |
@@ -212,6 +213,16 @@ postProcesses: [
   { type: "scanlines", enabled: true, settings: { intensity: 0.2 } }
 ]
 ```
+
+---
+
+## Native Animation
+
+Social posts, stories, reels, and carousel slides can use native Efecto layer animations. Do not use Tailwind `animate-*`, `transition-*`, or `duration-*` classes.
+
+Workflow: inspect the selected artboard or nodes, call `list_animation_presets`, then use `apply_animation_plan`. Animate the hook first: background/photo, hero headline, supporting line, swipe cue or CTA, then decorative details. For carousel/story motion, add exits only when the user asks for an outro or a video-style sequence.
+
+Good defaults: 0.35-0.6s for the headline or hero image, 0.18-0.35s for badges/icons/details, 0.04-0.1s stagger. Use `pop-spark`, `bounce-in`, `mask-reveal`, or `iris-reveal` when the brand needs thumb-stopping energy; otherwise keep it to `fade-in`, `slide-in`, and `scale-in`.
 
 ---
 

--- a/efecto/skills/social-media/SKILL.md
+++ b/efecto/skills/social-media/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 68 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -97,7 +97,7 @@ batch_update  updates: [
 ]
 ```
 
-### All 69 Tools
+### All 68 Tools
 
 | Category | Tools |
 |----------|-------|

--- a/efecto/skills/web-design/SKILL.md
+++ b/efecto/skills/web-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 68 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ---
 

--- a/efecto/skills/web-design/SKILL.md
+++ b/efecto/skills/web-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ---
 
@@ -171,9 +171,17 @@ Repeat Steps 4-6 to add more sections, adjust styling, and refine the design. Th
 |------|---------|
 | `update_node` | Updates any node property (className, textContent, tag, style, src, link, elementId, etc.) |
 | `update_class` | Shortcut: replaces only className on a node |
-| `update_artboard` | Updates artboard properties (name, size, background, className) |
+| `update_artboard` | Updates artboard properties (name, size, background, className, `timelineDuration`) |
 | `batch_update` | Updates multiple nodes in one call (bulk styling) |
 | `replace_section` | Replaces a node and its children with new JSX |
+
+### Animation
+
+| Tool | Purpose |
+|------|---------|
+| `list_animation_presets` | Lists native Efecto animation presets with ids, categories, defaults, and supported controls |
+| `apply_animation_plan` | Applies a validated multi-layer animation plan in one call |
+| `clear_animations` | Clears native animations from nodes, the selection, an artboard, or the whole document |
 
 ### Organizing Structure
 
@@ -255,6 +263,53 @@ Repeat Steps 4-6 to add more sections, adjust styling, and refine the design. Th
 | Tool | Purpose |
 |------|---------|
 | `search_images` | Search for free stock images (Lummi). No session required. Returns URLs to use with `add_node` or `set_fill`. |
+
+---
+
+## Native Animation — Animate Existing Designs
+
+Efecto has a native layer animation system. Do **not** use Tailwind `animate-*`, `transition-*`, or `duration-*` classes as the animation authoring path.
+
+Workflow for "animate this":
+
+1. Inspect the target with `get_selection`, `get_document`, `get_node_tree`, or `list_artboards`.
+2. Call `list_animation_presets` to see supported preset IDs and settings.
+3. Pick the meaningful layers: hero image, headline, supporting copy, CTA, cards, icons, or product visuals. Avoid animating every nested child.
+4. Call `apply_animation_plan` with timed entries. Use `mode: "replace"` for a new motion system or `mode: "append"` to add exit/outro animations.
+5. Set `timelineDuration` with `update_artboard` when the artboard needs a deliberate playback end.
+6. Use `select_nodes` to highlight the changed layers.
+
+Timing defaults:
+
+- Small UI elements: 0.18-0.35s.
+- Hero/slide elements: 0.35-0.6s.
+- Sibling stagger: 0.04-0.12s.
+- Entrances: `ease-out`.
+- Exits: `ease-in`.
+
+Preset guidance:
+
+- `fade-in`: subtle supporting content.
+- `slide-in`: directional reveals, usually 16-48px.
+- `scale-in`: cards, product shots, badges, modals.
+- `blur-in`: cinematic/editorial reveals.
+- `tilt-in`, `spin-in`, `bounce-in`, `pop-spark`: playful or promotional moments.
+- `mask-reveal`, `iris-reveal`: high-impact hero or title reveals.
+- Exit presets (`fade-out`, `slide-out`, `scale-out`, etc.) should leave enough reading time before they begin.
+
+Text nodes can use `appearBy: "word"` or `"line"` for headline reveals. Use `"char"` only for kinetic title moments; non-text nodes must use `"block"`.
+
+Example:
+
+```
+apply_animation_plan
+  mode: "replace"
+  animations: [
+    { nodeId: "<headline-id>", presetId: "fade-in", offset: 0, settings: { duration: 0.55, easing: "ease-out", appearBy: "word" } },
+    { nodeId: "<hero-image-id>", presetId: "scale-in", offset: 0.08, settings: { duration: 0.5, easing: "ease-out", scaleFrom: 0.96 } },
+    { nodeId: "<cta-id>", presetId: "slide-in", offset: 0.28, settings: { duration: 0.35, easing: "ease-out", direction: "up", distance: 20 } }
+  ]
+```
 
 ---
 

--- a/skills/graphic-design/SKILL.md
+++ b/skills/graphic-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -96,14 +96,15 @@ batch_update  updates: [
 ]
 ```
 
-### All 66 Tools
+### All 69 Tools
 
 | Category | Tools |
 |----------|-------|
 | **Session** | `create_session`, `attach_session`, `wait_for_connection`, `session_status`, `close_session` |
 | **Reading** | `get_document`, `get_selection`, `get_node_tree`, `list_artboards`, `find_nodes` |
 | **Creating** | `create_artboard`, `add_section`, `add_node` |
-| **Modifying** | `update_node`, `update_class`, `update_artboard` (now accepts `speakerNotes` for slides), `batch_update`, `replace_section` |
+| **Modifying** | `update_node`, `update_class`, `update_artboard` (accepts `speakerNotes` for slides and `timelineDuration` for animation), `batch_update`, `replace_section` |
+| **Animation** | `list_animation_presets`, `apply_animation_plan`, `clear_animations` |
 | **Organizing** | `move_node`, `duplicate_node`, `duplicate_artboard`, `group_nodes`, `ungroup_node`, `reorder_node` |
 | **Selection** | `select_nodes`, `deselect_all`, `set_visibility`, `delete_nodes`, `delete_artboard` |
 | **Alignment** | `align_nodes`, `distribute_nodes` |
@@ -217,6 +218,16 @@ add_node
 ```
 
 **Best for**: Presentation backgrounds, poster visuals, event graphics, blog hero images, OG cards with distinctive visual treatments.
+
+---
+
+## Native Animation
+
+Graphic assets can use native Efecto layer animations when the user asks for motion, slides, reels, or presentation playback. Do not use Tailwind `animate-*`, `transition-*`, or `duration-*` classes.
+
+Workflow: inspect the target, call `list_animation_presets`, then apply a compact plan with `apply_animation_plan`. Animate hierarchy first: background or hero visual, headline, supporting detail, CTA or event details, then secondary ornaments. Use `update_artboard` with `timelineDuration` when the motion needs a deliberate ending.
+
+Good defaults: 0.35-0.6s for hero/title motion, 0.18-0.35s for smaller details, 0.04-0.12s stagger, `ease-out` entrances, `ease-in` exits. For title text, use `appearBy: "word"` or `"line"`; reserve `"char"` for kinetic poster moments.
 
 ---
 

--- a/skills/graphic-design/SKILL.md
+++ b/skills/graphic-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 68 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -96,7 +96,7 @@ batch_update  updates: [
 ]
 ```
 
-### All 69 Tools
+### All 68 Tools
 
 | Category | Tools |
 |----------|-------|

--- a/skills/social-media/SKILL.md
+++ b/skills/social-media/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -97,7 +97,7 @@ batch_update  updates: [
 ]
 ```
 
-### All 66 Tools
+### All 69 Tools
 
 | Category | Tools |
 |----------|-------|
@@ -105,6 +105,7 @@ batch_update  updates: [
 | **Reading** | `get_document`, `get_selection`, `get_node_tree`, `list_artboards`, `find_nodes` |
 | **Creating** | `create_artboard`, `add_section`, `add_node` |
 | **Modifying** | `update_node`, `update_class`, `update_artboard`, `batch_update`, `replace_section` |
+| **Animation** | `list_animation_presets`, `apply_animation_plan`, `clear_animations` |
 | **Organizing** | `move_node`, `duplicate_node`, `duplicate_artboard`, `group_nodes`, `ungroup_node`, `reorder_node` |
 | **Selection** | `select_nodes`, `deselect_all`, `set_visibility`, `delete_nodes`, `delete_artboard` |
 | **Alignment** | `align_nodes`, `distribute_nodes` |
@@ -212,6 +213,16 @@ postProcesses: [
   { type: "scanlines", enabled: true, settings: { intensity: 0.2 } }
 ]
 ```
+
+---
+
+## Native Animation
+
+Social posts, stories, reels, and carousel slides can use native Efecto layer animations. Do not use Tailwind `animate-*`, `transition-*`, or `duration-*` classes.
+
+Workflow: inspect the selected artboard or nodes, call `list_animation_presets`, then use `apply_animation_plan`. Animate the hook first: background/photo, hero headline, supporting line, swipe cue or CTA, then decorative details. For carousel/story motion, add exits only when the user asks for an outro or a video-style sequence.
+
+Good defaults: 0.35-0.6s for the headline or hero image, 0.18-0.35s for badges/icons/details, 0.04-0.1s stagger. Use `pop-spark`, `bounce-in`, `mask-reveal`, or `iris-reveal` when the brand needs thumb-stopping energy; otherwise keep it to `fade-in`, `slide-in`, and `scale-in`.
 
 ---
 

--- a/skills/social-media/SKILL.md
+++ b/skills/social-media/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 68 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ### How It Works
 
@@ -97,7 +97,7 @@ batch_update  updates: [
 ]
 ```
 
-### All 69 Tools
+### All 68 Tools
 
 | Category | Tools |
 |----------|-------|

--- a/skills/web-design/SKILL.md
+++ b/skills/web-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 68 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ---
 

--- a/skills/web-design/SKILL.md
+++ b/skills/web-design/SKILL.md
@@ -50,7 +50,7 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
-Once installed, you'll have access to 61 design tools plus a standalone image search tool. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
+Once installed, you'll have access to 69 MCP tools, including image search and native animation authoring. The MCP server connects your agent to the Efecto design canvas at [efecto.app](https://efecto.app).
 
 ---
 
@@ -171,9 +171,17 @@ Repeat Steps 4-6 to add more sections, adjust styling, and refine the design. Th
 |------|---------|
 | `update_node` | Updates any node property (className, textContent, tag, style, src, link, elementId, etc.) |
 | `update_class` | Shortcut: replaces only className on a node |
-| `update_artboard` | Updates artboard properties (name, size, background, className) |
+| `update_artboard` | Updates artboard properties (name, size, background, className, `timelineDuration`) |
 | `batch_update` | Updates multiple nodes in one call (bulk styling) |
 | `replace_section` | Replaces a node and its children with new JSX |
+
+### Animation
+
+| Tool | Purpose |
+|------|---------|
+| `list_animation_presets` | Lists native Efecto animation presets with ids, categories, defaults, and supported controls |
+| `apply_animation_plan` | Applies a validated multi-layer animation plan in one call |
+| `clear_animations` | Clears native animations from nodes, the selection, an artboard, or the whole document |
 
 ### Organizing Structure
 
@@ -255,6 +263,53 @@ Repeat Steps 4-6 to add more sections, adjust styling, and refine the design. Th
 | Tool | Purpose |
 |------|---------|
 | `search_images` | Search for free stock images (Lummi). No session required. Returns URLs to use with `add_node` or `set_fill`. |
+
+---
+
+## Native Animation — Animate Existing Designs
+
+Efecto has a native layer animation system. Do **not** use Tailwind `animate-*`, `transition-*`, or `duration-*` classes as the animation authoring path.
+
+Workflow for "animate this":
+
+1. Inspect the target with `get_selection`, `get_document`, `get_node_tree`, or `list_artboards`.
+2. Call `list_animation_presets` to see supported preset IDs and settings.
+3. Pick the meaningful layers: hero image, headline, supporting copy, CTA, cards, icons, or product visuals. Avoid animating every nested child.
+4. Call `apply_animation_plan` with timed entries. Use `mode: "replace"` for a new motion system or `mode: "append"` to add exit/outro animations.
+5. Set `timelineDuration` with `update_artboard` when the artboard needs a deliberate playback end.
+6. Use `select_nodes` to highlight the changed layers.
+
+Timing defaults:
+
+- Small UI elements: 0.18-0.35s.
+- Hero/slide elements: 0.35-0.6s.
+- Sibling stagger: 0.04-0.12s.
+- Entrances: `ease-out`.
+- Exits: `ease-in`.
+
+Preset guidance:
+
+- `fade-in`: subtle supporting content.
+- `slide-in`: directional reveals, usually 16-48px.
+- `scale-in`: cards, product shots, badges, modals.
+- `blur-in`: cinematic/editorial reveals.
+- `tilt-in`, `spin-in`, `bounce-in`, `pop-spark`: playful or promotional moments.
+- `mask-reveal`, `iris-reveal`: high-impact hero or title reveals.
+- Exit presets (`fade-out`, `slide-out`, `scale-out`, etc.) should leave enough reading time before they begin.
+
+Text nodes can use `appearBy: "word"` or `"line"` for headline reveals. Use `"char"` only for kinetic title moments; non-text nodes must use `"block"`.
+
+Example:
+
+```
+apply_animation_plan
+  mode: "replace"
+  animations: [
+    { nodeId: "<headline-id>", presetId: "fade-in", offset: 0, settings: { duration: 0.55, easing: "ease-out", appearBy: "word" } },
+    { nodeId: "<hero-image-id>", presetId: "scale-in", offset: 0.08, settings: { duration: 0.5, easing: "ease-out", scaleFrom: 0.96 } },
+    { nodeId: "<cta-id>", presetId: "slide-in", offset: 0.28, settings: { duration: 0.35, easing: "ease-out", direction: "up", distance: 20 } }
+  ]
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Update public plugin README/AGENTS tool counts to 69
- Add native Efecto animation workflow guidance to web, graphic, and social skills
- Keep skills/ and efecto/skills/ mirrored for both install paths

## Verification
- diff -qr skills efecto/skills

## Companion
- App/API PR: https://github.com/pablostanley/efecto-app/pull/905